### PR TITLE
Fix typo in `tls.yaml`

### DIFF
--- a/model/registry/deprecated/tls.yaml
+++ b/model/registry/deprecated/tls.yaml
@@ -6,6 +6,6 @@ groups:
       - id: tls.client.server_name
         type: string
         stability: experimental
-        deprecated: "Replaced by `server.address."
+        deprecated: "Replaced by `server.address`."
         brief: "Deprecated, use `server.address` instead."
         examples: ["opentelemetry.io"]


### PR DESCRIPTION
Noticed reviewing https://github.com/open-telemetry/semantic-conventions-java/pull/70